### PR TITLE
feat: add creation of server based on an other server with a PITR

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -20,9 +20,11 @@ resource "azurerm_postgresql_flexible_server" "this" {
     start_hour   = var.maintenance_window.start_hour
     start_minute = var.maintenance_window.start_minute
   }
-  zone = var.zone
-
-  depends_on = [azurerm_private_dns_zone_virtual_network_link.dns_net]
+  zone                              = var.zone
+  create_mode                       = var.create_mode
+  point_in_time_restore_time_in_utc = try(var.point_in_time_restore_time_in_utc, null)
+  source_server_id                  = try(var.source_server_id, null)
+  depends_on                        = [azurerm_private_dns_zone_virtual_network_link.dns_net]
 }
 
 resource "azurerm_postgresql_flexible_server_configuration" "this" {

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ resource "azurerm_postgresql_flexible_server" "this" {
   location                      = var.location
   version                       = var.pg_version
   delegated_subnet_id           = var.create_subnet ? azurerm_subnet.this[0].id : var.delegated_subnet_id
-  private_dns_zone_id           = azurerm_private_dns_zone.this.id
+  private_dns_zone_id           = var.create_private_dns_zone ? azurerm_private_dns_zone.this.id
   public_network_access_enabled = var.public_network_access_enabled
   administrator_login           = var.administrator_login
   administrator_password        = random_password.this.result
@@ -52,7 +52,7 @@ moved {
 }
 
 resource "azurerm_subnet" "this" {
-  count                = var.create_subnet ? 1 : 0
+  count                = var.create_subnet != false ? 1 : 0
   name                 = format("%s-snet", var.subnet_name_prefix != null ? var.subnet_name_prefix : var.name)
   resource_group_name  = var.vnet_resource_group_name != null ? var.vnet_resource_group_name : var.resource_group_name
   virtual_network_name = var.virtual_network_name
@@ -73,6 +73,7 @@ resource "azurerm_subnet" "this" {
 
 
 resource "azurerm_private_dns_zone" "this" {
+  count               = var.create_private_dns_zone != false ? 1 : 0
   name                = format("%s.privatelink.postgres.database.azure.com", var.private_dns_zone_name_prefix != null ? var.private_dns_zone_name_prefix : var.name)
   resource_group_name = var.resource_group_name
 }

--- a/main.tf
+++ b/main.tf
@@ -85,7 +85,7 @@ moved {
 
 
 resource "azurerm_private_dns_zone_virtual_network_link" "dns_net" {
-  count                 = var.virtual_network_id && var.create_private_dns_zone ? 1 : 0
+  count                 = var.virtual_network_id != null && var.create_private_dns_zone ? 1 : 0
   name                  = format("%s-zdns-nl", azurerm_private_dns_zone.this[0].name)
   private_dns_zone_name = azurerm_private_dns_zone.this[0].name
   resource_group_name   = var.resource_group_name

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ resource "azurerm_postgresql_flexible_server" "this" {
   location                      = var.location
   version                       = var.pg_version
   delegated_subnet_id           = var.create_subnet ? azurerm_subnet.this[0].id : var.delegated_subnet_id
-  private_dns_zone_id           = var.create_private_dns_zone ? azurerm_private_dns_zone.this.id
+  private_dns_zone_id           = var.create_private_dns_zone ? azurerm_private_dns_zone.this.id : null
   public_network_access_enabled = var.public_network_access_enabled
   administrator_login           = var.administrator_login
   administrator_password        = random_password.this.result
@@ -80,7 +80,7 @@ resource "azurerm_private_dns_zone" "this" {
 
 
 resource "azurerm_private_dns_zone_virtual_network_link" "dns_net" {
-  count                = var.virtual_network_id != null ? 1 : 0
+  count                 = var.virtual_network_id != null ? 1 : 0
   name                  = format("%s-zdns-nl", azurerm_private_dns_zone.this.name)
   private_dns_zone_name = azurerm_private_dns_zone.this.name
   resource_group_name   = var.resource_group_name

--- a/main.tf
+++ b/main.tf
@@ -77,7 +77,9 @@ resource "azurerm_private_dns_zone" "this" {
   resource_group_name = var.resource_group_name
 }
 
+
 resource "azurerm_private_dns_zone_virtual_network_link" "dns_net" {
+  count                = var.virtual_network_id != null ? 1 : 0
   name                  = format("%s-zdns-nl", azurerm_private_dns_zone.this.name)
   private_dns_zone_name = azurerm_private_dns_zone.this.name
   resource_group_name   = var.resource_group_name

--- a/variables.tf
+++ b/variables.tf
@@ -67,6 +67,13 @@ variable "create_subnet" {
   default     = false
 }
 
+variable "create_private_dns_zone" {
+  description = "Create Private dns zone for PostgreSQL Flexible Server."
+  type        = bool
+  default     = false
+}
+
+
 variable "delegated_subnet_id" {
   description = "Delegated Subnet ID for PostgreSQL Flexible Server."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -77,7 +77,7 @@ variable "create_private_dns_zone" {
 variable "delegated_subnet_id" {
   description = "Delegated Subnet ID for PostgreSQL Flexible Server."
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "virtual_network_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -183,3 +183,21 @@ variable "instance_lock" {
   type        = bool
   default     = true
 }
+
+variable "create_mode" {
+  description = "The mode to create a new PostgreSQL Flexible Server. useful for PointInTimeRestore"
+  type        = string
+  default     = "Default"
+}
+
+variable "source_server_id" {
+  description = "The source PostgreSQL Flexible Server ID to restore from. Required when create_mode is PointInTimeRestore."
+  type        = string
+  default     = null
+}
+
+variable "point_in_time_restore_time_in_utc" {
+  description = "The point in time to restore the PostgreSQL Flexible Server to. Required when create_mode is PointInTimeRestore."
+  type        = string
+  default     = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -76,11 +76,13 @@ variable "delegated_subnet_id" {
 variable "virtual_network_name" {
   description = "Virtual Network Name where Subnet will be created."
   type        = string
+  default     = null
 }
 
 variable "virtual_network_id" {
   description = "Virtual Network ID where Subnet will be created."
   type        = string
+  default     = null
 }
 
 variable "virtual_network_pipeline_id" {


### PR DESCRIPTION
* Purpose

Sometimes for QA server, we want to make a exact copy of the production one, so we may want to create it from for a server
PITR at a specific time.

